### PR TITLE
Fix setup.py, add distclass=BinaryDistribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,6 @@ setup(name='prometeo-dsl',
         'include/prometeo/*', \
         'include/blasfeo/*']},
     include_package_data=True,
-    zip_safe=False)
+    zip_safe=False,
+    distclass=BinaryDistribution
+)


### PR DESCRIPTION
Add `distclass=BinaryDistribution` in order to make the wheel recognized as a
[Platform Wheel](https://packaging.python.org/guides/distributing-packages-using-setuptools/#platform-wheels) and allow different version for different platforms. 