### PR TITLE
Meta info restructure (WIP)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-python3 -m pip install cibuildwheel==1.3.0
-python3 -m cibuildwheel --output-dir wheelhouse
-python3 -m pip install twine
-python3 -m twine upload wheelhouse/*.whl

--- a/experimental/meta_info/case1.py
+++ b/experimental/meta_info/case1.py
@@ -1,0 +1,22 @@
+from prometeo import *
+
+n : dims = 10
+
+class ClassA():
+    A : pmat = pmat(n,n)
+
+    def method1(self, arg1 : int) -> int:
+        return 0
+
+class ClassB():
+    B : ClassA = ClassA()
+
+def main() -> int:
+    A : pmat = pmat(n,n)
+    D : ClassA = ClassA()
+    return 0
+# def main() -> int:
+#     A : pmat = pmat(n,n)
+#     E : ClassB = ClassB()
+#     return 0
+

--- a/experimental/sized_type_checking/case1.py
+++ b/experimental/sized_type_checking/case1.py
@@ -1,0 +1,21 @@
+from prometeo import *
+
+n : dims = 10
+
+class ClassA():
+    A : pmat = pmat(n,n)
+
+    def method1(self, arg1 : int) -> int:
+        return 0
+
+class ClassB():
+    attr1 : ClassA = ClassA()
+
+class ClassC():
+    attr2 : ClassB = ClassB()
+
+def main() -> int:
+    A : pmat = pmat(n,n)
+    D : ClassA = ClassA()
+    return 0
+

--- a/experimental/sized_type_checking/case1.py
+++ b/experimental/sized_type_checking/case1.py
@@ -16,6 +16,6 @@ class ClassC():
 
 def main() -> int:
     A : pmat = pmat(n,n)
-    D : ClassA = ClassA()
+    D : ClassC = ClassC()
     return 0
 

--- a/prometeo/cgen/code_gen_c.py
+++ b/prometeo/cgen/code_gen_c.py
@@ -164,9 +164,9 @@ def to_source(node, module_name, indent_with=' ' * 4, add_line_information=False
     json_file = 'typed_record.json'
     with open(json_file, 'w') as f:
         json.dump(generator.typed_record, f, indent=4, sort_keys=True)
-    json_file = 'new_typed_record.json'
+    json_file = 'meta_info.json'
     with open(json_file, 'w') as f:
-        json.dump(generator.new_typed_record, f, indent=3, sort_keys=True)
+        json.dump(generator.meta_info, f, indent=3, sort_keys=True)
     json_file = 'var_dim_record.json'
     with open(json_file, 'w') as f:
         json.dump(generator.var_dim_record, f, indent=4, sort_keys=True)
@@ -231,6 +231,13 @@ def Num_or_Name(node):
             raise cgenException('node.op is not of type ast.USub.\n', node.lineno)
     else:
         raise cgenException('node is not of type ast.Num nor ast.Name.\n', node.lineno)
+
+# def process_annotation(ann_node):
+#     if isinstance(ann_node, ast.Name):
+#         return ann_node.id
+#     elif isinstance(ann_node, ast.Subscript):
+#         return ann_node.value.id + '[' + Num_or_Name(ann_node.slice.value.elts[0]) + \
+#             ',' +  Num_or_Name(ann_node.slice.value.elts[0]) + ']' 
 
 class Delimit(object):
     """A context manager that can add enclosing
@@ -325,6 +332,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.heap64_size = ___c_pmt_64_heap_size 
 
         self.typed_record = {'global': dict()}
+        self.meta_info = {'global': dict()}
         self.heap8_record = {'global': dict()}
         self.heap64_record = {'global': dict()}
         self.scope = 'global'
@@ -417,7 +425,8 @@ class SourceGenerator(ExplicitNodeVisitor):
         """ self.write is a closure for performance (to reduce the number
             of attribute lookups).
         """
-        # self.new_typed_record['attr'] = []
+        self.meta_info[self.scope]['attr'] = dict()
+        self.meta_info[self.scope]['methods'] = dict()
         for item in params:
             if isinstance(item, ast.AnnAssign):
                 set_precedence(item, item.target, item.annotation)
@@ -429,8 +438,9 @@ class SourceGenerator(ExplicitNodeVisitor):
                 # annotation = ast.parse(item.annotation.s).body[0]
                 # if 'value' in annotation.value.__dict__:
                 type_py = annotation.id
+                self.meta_info[self.scope]['attr'][item.target.id] = type_py
 
-                if annotation.id is 'List':
+                if type_py is 'List':
                     if item.value.func.id is not 'plist': 
                         raise cgenException('Cannot create Lists without using'
                             ' plist constructor.', item.lineno)
@@ -465,10 +475,20 @@ class SourceGenerator(ExplicitNodeVisitor):
                         self.write('%s' %ann, ' ', '%s' %item.target.id, \
                             '[%s' %array_size, '];\n', dest = 'hdr')
                 else:
-                    type_c = pmt_temp_types[type_py]
-                    self.write('%s' %type_c, ' ', '%s' %item.target.id, ';\n', dest = 'hdr')
-                    # self.conditional_write(' = ', item.value, ';')
-                    self.typed_record[self.scope][item.target.id] = type_py
+                    # not a List
+                    ann = type_py
+
+                    # check for user-defined types
+                    if ann in usr_temp_types:
+                        self.write('struct %s' %ann, ' ',  item.target.id, '___;\n', dest = 'hdr')
+                        self.write('struct %s *' %ann, ' ',  item.target.id, ';\n', dest = 'hdr')
+                        # self.statement(node, node.annotation, ' ', node.target, '= &', node.target, '___;')
+                    else:
+                        type_c = pmt_temp_types[type_py]
+                        self.write('%s' %type_c, ' ', '%s' %item.target.id, ';\n', dest = 'hdr')
+
+                        # self.conditional_write(' = ', item.value, ';')
+                        self.typed_record[self.scope][item.target.id] = type_py
                 # else:
                 #     type_py = annotation.id
                 #     type_c = pmt_temp_types[type_py]
@@ -476,6 +496,7 @@ class SourceGenerator(ExplicitNodeVisitor):
                 #     # self.conditional_write(' = ', item.value, ';')
                 #     self.typed_record[self.scope][item.target.id] = type_py
             elif isinstance(item, ast.FunctionDef):
+                self.meta_info[self.scope]['methods'][item.name] = dict()
                 # build argument mangling
                 f_name_len = len(item.name)
                 pre_mangl = '_Z%s' %f_name_len 
@@ -495,6 +516,8 @@ class SourceGenerator(ExplicitNodeVisitor):
                     ret_type = self.get_returns(item).id
                 else:
                     ret_type = self.get_returns(item).value
+
+                self.meta_info[self.scope]['methods'][item.name]['return_type'] = ret_type
 
                 if ret_type is None: 
                     ret_type = 'None'
@@ -516,7 +539,9 @@ class SourceGenerator(ExplicitNodeVisitor):
                             item.name, post_mangl) , ')', '(%s *self' %name, \
                             dest = 'hdr')
 
-                self.visit_arguments(item.args, 'hdr')
+
+                args_list = self.visit_arguments(item.args, 'hdr')
+                self.meta_info[self.scope]['methods'][item.name]['args'] = args_list
                 self.write(');\n', dest = 'hdr')
                 # insert back self argument 
                 item.args.args.insert(0, self_arg)
@@ -655,6 +680,9 @@ class SourceGenerator(ExplicitNodeVisitor):
                     else:
                         raise cgenException('Cannot declare attribute without' 
                             ' initialization.\n', item.lineno)
+                elif ann in usr_temp_types:
+                    self.write('\nobject->', item.target.id, ' = &(object->', item.target.id, '___);\n', dest = 'src')
+                    self.write(ann, '_init(object->', item.target.id, ');\n', dest='src')
                 else:
                     if item.value != None:
                         if hasattr(item.value, 'value') is False:
@@ -770,6 +798,8 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.else_body(node.orelse)
 
     def visit_arguments(self, node, dest_in):
+        # args_list returned for class meta-info update
+        args_list = dict()
         want_comma = []
 
         def write_comma():
@@ -799,6 +829,7 @@ class SourceGenerator(ExplicitNodeVisitor):
                 else:
                     arg_type_py = arg.annotation.id
 
+                args_list[arg.arg] = arg_type_py
                 arg_type_c = pmt_temp_types[arg_type_py]
                 self.write(write_comma, arg_type_c,' ',arg.arg, dest = dest_in)
 
@@ -815,6 +846,8 @@ class SourceGenerator(ExplicitNodeVisitor):
                 self.write(write_comma, '*')
             loop_args(kwonlyargs, node.kw_defaults)
         self.conditional_write(write_comma, '**', node.kwarg, dest = 'src')
+
+        return args_list
 
     def build_arg_mangling(self, node):
         want_comma = []
@@ -1440,7 +1473,7 @@ class SourceGenerator(ExplicitNodeVisitor):
     def visit_ClassDef(self, node):
         self.scope = self.scope + '@' + node.name
         self.typed_record[self.scope] = dict()
-        # self.new_typed_record[self.scope] = dict()
+        self.meta_info[self.scope] = dict()
         self.var_dim_record[self.scope] = dict()
         self.heap8_record[self.scope] = 0 
         self.heap64_record[self.scope] = 0 

--- a/prometeo/cgen/code_gen_c.py
+++ b/prometeo/cgen/code_gen_c.py
@@ -164,6 +164,9 @@ def to_source(node, module_name, indent_with=' ' * 4, add_line_information=False
     json_file = 'typed_record.json'
     with open(json_file, 'w') as f:
         json.dump(generator.typed_record, f, indent=4, sort_keys=True)
+    json_file = 'new_typed_record.json'
+    with open(json_file, 'w') as f:
+        json.dump(generator.new_typed_record, f, indent=3, sort_keys=True)
     json_file = 'var_dim_record.json'
     with open(json_file, 'w') as f:
         json.dump(generator.var_dim_record, f, indent=4, sort_keys=True)
@@ -414,6 +417,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         """ self.write is a closure for performance (to reduce the number
             of attribute lookups).
         """
+        # self.new_typed_record['attr'] = []
         for item in params:
             if isinstance(item, ast.AnnAssign):
                 set_precedence(item, item.target, item.annotation)
@@ -425,6 +429,7 @@ class SourceGenerator(ExplicitNodeVisitor):
                 # annotation = ast.parse(item.annotation.s).body[0]
                 # if 'value' in annotation.value.__dict__:
                 type_py = annotation.id
+
                 if annotation.id is 'List':
                     if item.value.func.id is not 'plist': 
                         raise cgenException('Cannot create Lists without using'
@@ -515,6 +520,8 @@ class SourceGenerator(ExplicitNodeVisitor):
                 self.write(');\n', dest = 'hdr')
                 # insert back self argument 
                 item.args.args.insert(0, self_arg)
+            else:
+                raise cgenException('Classes can only contain attributes and methods', item.lineno)
         
     def write_class_method_prototypes(self, *params, name):
         """ self.write is a closure for performance (to reduce the number
@@ -1433,6 +1440,7 @@ class SourceGenerator(ExplicitNodeVisitor):
     def visit_ClassDef(self, node):
         self.scope = self.scope + '@' + node.name
         self.typed_record[self.scope] = dict()
+        # self.new_typed_record[self.scope] = dict()
         self.var_dim_record[self.scope] = dict()
         self.heap8_record[self.scope] = 0 
         self.heap64_record[self.scope] = 0 

--- a/prometeo/cpmt/Makefile
+++ b/prometeo/cpmt/Makefile
@@ -1,12 +1,15 @@
+PMT_FLAGS = -DMEASURE_TIMINGS
 CC = gcc
 # CC = g++
 # CC = clang
 CFLAGS = -std=c99
 CFLAGS += -fPIC
+CFLAGS += $(PMT_FLAGS)
 PREFIX = ./..
 SRCS += pmat_blasfeo_wrapper.c
 SRCS += pvec_blasfeo_wrapper.c
 SRCS += pmt_aux.c
+SRCS += timing.c
 CFLAGS +=-I../../external/blasfeo/include/
 OPT_LD_FLAGS = 
 

--- a/prometeo/cpmt/timing.c
+++ b/prometeo/cpmt/timing.c
@@ -84,7 +84,7 @@ double prometeo_toc(prometeo_timer* t) { return ds1401_tic_read() - t->time; }
 
 #else
 
-// #if __STDC_VERSION__ >= 199901L  // C99 Mode
+#if __STDC_VERSION__ >= 199901L  // C99 Mode
 
 /* read current time */
 void prometeo_tic(prometeo_timer* t) { gettimeofday(&t->tic, 0); }

--- a/prometeo/cpmt/timing.c
+++ b/prometeo/cpmt/timing.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+ * Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+ * Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+ * Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+ *
+ * This file is adapted from acados.
+ *
+ * The 2-Clause BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.;
+ */
+
+
+#include "timing.h"
+
+#ifdef MEASURE_TIMINGS
+
+#if (defined _WIN32 || defined _WIN64) && !(defined __MINGW32__ || defined __MINGW64__)
+
+void prometeo_tic(prometeo_timer* t)
+{
+    QueryPerformanceFrequency(&t->freq);
+    QueryPerformanceCounter(&t->tic);
+}
+
+double prometeo_toc(prometeo_timer* t)
+{
+    QueryPerformanceCounter(&t->toc);
+    return ((t->toc.QuadPart - t->tic.QuadPart) / (double) t->freq.QuadPart);
+}
+
+#elif defined(__APPLE__)
+void prometeo_tic(prometeo_timer* t)
+{
+    /* read current clock cycles */
+    t->tic = mach_absolute_time();
+}
+
+double prometeo_toc(prometeo_timer* t)
+{
+    uint64_t duration; /* elapsed time in clock cycles*/
+
+    t->toc = mach_absolute_time();
+    duration = t->toc - t->tic;
+
+    /*conversion from clock cycles to nanoseconds*/
+    mach_timebase_info(&(t->tinfo));
+    duration *= t->tinfo.numer;
+    duration /= t->tinfo.denom;
+
+    return (double) duration / 1e9;
+}
+
+#elif defined(__DSPACE__)
+
+void prometeo_tic(prometeo_timer* t)
+{
+    ds1401_tic_start();
+    t->time = ds1401_tic_read();
+}
+
+double prometeo_toc(prometeo_timer* t) { return ds1401_tic_read() - t->time; }
+
+#else
+
+// #if __STDC_VERSION__ >= 199901L  // C99 Mode
+
+/* read current time */
+void prometeo_tic(prometeo_timer* t) { gettimeofday(&t->tic, 0); }
+/* return time passed since last call to tic on this timer */
+double prometeo_toc(prometeo_timer* t)
+{
+    struct timeval temp;
+
+    gettimeofday(&t->toc, 0);
+
+    if ((t->toc.tv_usec - t->tic.tv_usec) < 0)
+    {
+        temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec - 1;
+        temp.tv_usec = 1000000 + t->toc.tv_usec - t->tic.tv_usec;
+    }
+    else
+    {
+        temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec;
+        temp.tv_usec = t->toc.tv_usec - t->tic.tv_usec;
+    }
+
+    return (double) temp.tv_sec + (double) temp.tv_usec / 1e6;
+}
+
+#else  // ANSI C Mode
+
+/* read current time */
+void prometeo_tic(prometeo_timer* t) { clock_gettime(CLOCK_MONOTONIC, &t->tic); }
+/* return time passed since last call to tic on this timer */
+double prometeo_toc(prometeo_timer* t)
+{
+    struct timespec temp;
+
+    clock_gettime(CLOCK_MONOTONIC, &t->toc);
+
+    if ((t->toc.tv_nsec - t->tic.tv_nsec) < 0)
+    {
+        temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec - 1;
+        temp.tv_nsec = 1000000000 + t->toc.tv_nsec - t->tic.tv_nsec;
+    }
+    else
+    {
+        temp.tv_sec = t->toc.tv_sec - t->tic.tv_sec;
+        temp.tv_nsec = t->toc.tv_nsec - t->tic.tv_nsec;
+    }
+
+    return (double) temp.tv_sec + (double) temp.tv_nsec / 1e9;
+}
+
+#endif  // __STDC_VERSION__ >= 199901L
+
+#endif  // (defined _WIN32 || _WIN64)
+
+#else  // Dummy functions when timing is off
+
+void prometeo_tic(prometeo_timer *t) {}
+double prometeo_toc(prometeo_timer *t) { return 0; }
+
+#endif  // MEASURE_TIMINGS

--- a/prometeo/cpmt/timing.h
+++ b/prometeo/cpmt/timing.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Gianluca Frison, Dimitris Kouzoupis, Robin Verschueren,
+ * Andrea Zanelli, Niels van Duijkeren, Jonathan Frey, Tommaso Sartor,
+ * Branimir Novoselnik, Rien Quirynen, Rezart Qelibari, Dang Doan,
+ * Jonas Koenemann, Yutao Chen, Tobias Schöls, Jonas Schlagenhauf, Moritz Diehl
+ *
+ * This file is adapted from acados.
+ *
+ * The 2-Clause BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.;
+ */
+
+
+#ifndef PROMETEO_UTILS_TIMING_H_
+#define PROMETEO_UTILS_TIMING_H_
+
+// #include "acados/utils/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef MEASURE_TIMINGS
+#if (defined _WIN32 || defined _WIN64) && !(defined __MINGW32__ || defined __MINGW64__)
+
+/* Use Windows QueryPerformanceCounter for timing. */
+#include <Windows.h>
+
+/** A structure for keeping internal timer data. */
+typedef struct prometeo_timer_
+{
+    LARGE_INTEGER tic;
+    LARGE_INTEGER toc;
+    LARGE_INTEGER freq;
+} prometeo_timer;
+
+#elif defined(__APPLE__)
+
+#include <mach/mach_time.h>
+
+/** A structure for keeping internal timer data. */
+typedef struct prometeo_timer_
+{
+    uint64_t tic;
+    uint64_t toc;
+    mach_timebase_info_data_t tinfo;
+} prometeo_timer;
+
+#elif defined(__DSPACE__)
+
+#include <brtenv.h>
+
+typedef struct prometeo_timer_
+{
+    double time;
+} prometeo_timer;
+
+#else
+
+/* Use POSIX clock_gettime() for timing on non-Windows machines. */
+#include <time.h>
+
+#if __STDC_VERSION__ >= 199901L  // C99 Mode
+
+#include <sys/stat.h>
+#include <sys/time.h>
+
+typedef struct prometeo_timer_
+{
+    struct timeval tic;
+    struct timeval toc;
+} prometeo_timer;
+
+#else  // ANSI C Mode
+
+/** A structure for keeping internal timer data. */
+typedef struct prometeo_timer_
+{
+    struct timespec tic;
+    struct timespec toc;
+} prometeo_timer;
+
+#endif  // __STDC_VERSION__ >= 199901L
+
+#endif  // (defined _WIN32 || defined _WIN64)
+
+#else
+
+// Dummy type when timings are off
+typedef double prometeo_timer;
+
+#endif  // MEASURE_TIMINGS
+
+/** A function for measurement of the current time. */
+void prometeo_tic(prometeo_timer* t);
+
+/** A function which returns the elapsed time. */
+double prometeo_toc(prometeo_timer* t);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif  // PROMETEO_UTILS_TIMING_H_


### PR DESCRIPTION
Addressing https://github.com/zanellia/prometeo/issues/6. The AST parser now builds an additional data structure called meta_info. For example
```python
from prometeo import *

n : dims = 10

class ClassA():
    A : pmat = pmat(n,n)

    def method1(self, arg1 : int) -> int:
        return 0

class ClassB():
    attr1 : ClassA = ClassA()

class ClassC():
    attr2 : ClassB = ClassB()

def main() -> int:
    A : pmat = pmat(n,n)
    D : ClassC = ClassC()
    return 0
```

generates

```json
{
   "global": {},
   "global@ClassA": {
      "attr": {
         "A": "pmat"
      },
      "methods": {
         "method1": {
            "args": {
               "arg1": "int"
            },
            "return_type": "int"
         }
      }
   },
   "global@ClassB": {
      "attr": {
         "attr1": "ClassA"
      },
      "methods": {}
   },
   "global@ClassC": {
      "attr": {
         "attr2": "ClassB"
      },
      "methods": {}
   }
}
```